### PR TITLE
added authorship and contributor roles pages (issue 17), solved issue…

### DIFF
--- a/Governance/_toc.yml
+++ b/Governance/_toc.yml
@@ -50,6 +50,7 @@ parts:
     chapters:
     - file: concepts/concept-intro.md
       sections:
+      - file: concepts/authorship
       - file: concepts/backup
       - file: concepts/controlled-vocab
       - file: concepts/conventions
@@ -86,6 +87,7 @@ parts:
       sections:
       - file: tech/backup-checklist
       - file: tech/cf-checker
+      - file: tech/contributors
       - file: tech/drs
         sections:
         - file: tech/filenames

--- a/Governance/concepts/authorship.md
+++ b/Governance/concepts/authorship.md
@@ -1,0 +1,51 @@
+# Authorship
+
+Research output are usually the result of collaboration, so it is important to attribute the right roles to anyone involved.
+Often researchers don't distinguish between different levels of involvements and either add only the main authors, failing to recognise minor but still important contributions to the work, or they add anyone involved as an author.
+However, `author` is not the only possible option, most data portals and publishing standards now allow to use `contributor` to cover a range of different roles.
+ 
+```{note}
+Depending on the standard 
+```
+While only the authors will be included in the research output citation, the contributors will still feature prominently in the record metadata and webpage, and it is often possible for them to use their researcher-id to keep track of their contributions.
+This is particularly important for data curators who often don't appear as authors but can now be recognised for their role. This practice it is also useful to a user of the research output as it makes clear who is more likely to answer a specific question.
+ 
+Different potential roles are described in this book [technical resources section](../tech/contributors), an `author` in brief is `a person who has created or modified a research output in a substantial way`. 
+
+## Authorship policy
+
+This is not just a definition, it is part of the requirements set by the [Australian Code for the Responsible Conduct of Research 2018](https://www.nhmrc.gov.au/about-us/publications/australian-code-responsible-conduct-research-2018#download), and as such, it is really important to be careful when publishing not to breach this rule.
+A complete definition is available in the code itself; usually it is also possible to refer to the Authorship Policy of the research output publisher.
+An Authorship Policy helps a contributor to make the right decision when defining the authors and helps the managers to solve any potential dispute. It should include a clear definition on author and contributors, including their responsibilities and what action will be taken in case of a breach. 
+
+```{tip}
+A Task Force of the [FORCE11 Software Citation Implementation Working Group](https://github.com/force11/force11-sciwg) has published a useful guide on best practices for software portals: [Nine Best Practices for Research Software Registries and Repositories: A Concise Guide](https://arxiv.org/pdf/2012.13117.pdf). This includes a list of policies that should be established to help managing the portal. Some of these recommendations can be adopted also for smaller data or software collections.  
+```
+
+### Authorship Policy example
+
+```{note}
+This is the authorship policy for the [CLEX data collection on Zenodo](https://zenodo.org/communities/arc-coe-clex-data/about/). It is based on the [Australian Code for the Responsible Conduct of Research 2018](https://www.nhmrc.gov.au/about-us/publications/australian-code-responsible-conduct-research-2018#download).
+```
+
+You can only submit a dataset for which you are an author. 
+
+An author is a person who has created or modified a dataset in a substantial way, either as an individual or part of a group effort. 
+A dataset can have several co-authors. All co-authors should have made a significant contribution to the data. Each author needs to give their agreement to be listed as an author. In addition, if some co-authors are not from CLEX, they should give their agreement for the code to be listed under the CLEX Data Collection.
+
+It is possible to define contributors in the CLEX Data Collection, some of the potential contributor roles are:
+
+* Reviewer 
+  To qualify, the review needs to be a substantial effort, which results in improvements/changes being applied to the dataset. 
+
+* Curator 
+  Person tasked with reviewing, enhancing, cleaning, or standardizing the data and the associated metadata in a way that goes beyond the ordinary curation of the data collection
+
+* Content-expert 
+  Someone who contributed mainly by providing advice/review on the scientific validity of the data
+
+These definitions are based on the authorship and co-authorship policy on the Australian Code for the Responsible Conduct of Research 2018.
+
+You can only submit a modified dataset if the modifications add value to the data. For example, if you have applied some correction to an existing dataset, this effectively add values to the original data. Re-gridding a dataset is not enough to consider this a new dataset. The best option in this case is to cite the original data and the re-gridding code.
+
+When submitting a modified dataset, the authors are responsible to ensure the licensing and ethical terms of the original data allow for that submission. 

--- a/Governance/concepts/authorship.md
+++ b/Governance/concepts/authorship.md
@@ -5,12 +5,12 @@ Often researchers don't distinguish between different levels of involvements and
 However, `author` is not the only possible option, most data portals and publishing standards now allow to use `contributor` to cover a range of different roles.
  
 ```{note}
-Depending on the standard 
+Depending on the conventions followed by the publisher, `author` can be referred to as `creator` and `contributor` as `collaborator`.  
 ```
 While only the authors will be included in the research output citation, the contributors will still feature prominently in the record metadata and webpage, and it is often possible for them to use their researcher-id to keep track of their contributions.
 This is particularly important for data curators who often don't appear as authors but can now be recognised for their role. This practice it is also useful to a user of the research output as it makes clear who is more likely to answer a specific question.
  
-Different potential roles are described in this book [technical resources section](../tech/contributors), an `author` in brief is `a person who has created or modified a research output in a substantial way`. 
+Different potential roles are described in this book [technical resources section](../tech/contributors), an `author` in brief is "a person who has created or modified a research output in a substantial way". 
 
 ## Authorship policy
 
@@ -24,28 +24,27 @@ A Task Force of the [FORCE11 Software Citation Implementation Working Group](htt
 
 ### Authorship Policy example
 
-```{note}
-This is the authorship policy for the [CLEX data collection on Zenodo](https://zenodo.org/communities/arc-coe-clex-data/about/). It is based on the [Australian Code for the Responsible Conduct of Research 2018](https://www.nhmrc.gov.au/about-us/publications/australian-code-responsible-conduct-research-2018#download).
-```
+This example of authorship policy is taken from the [CLEX data collection on Zenodo](https://zenodo.org/communities/arc-coe-clex-data/about/). It is based on the [Australian Code for the Responsible Conduct of Research 2018](https://www.nhmrc.gov.au/about-us/publications/australian-code-responsible-conduct-research-2018#download).
 
-You can only submit a dataset for which you are an author. 
 
-An author is a person who has created or modified a dataset in a substantial way, either as an individual or part of a group effort. 
-A dataset can have several co-authors. All co-authors should have made a significant contribution to the data. Each author needs to give their agreement to be listed as an author. In addition, if some co-authors are not from CLEX, they should give their agreement for the code to be listed under the CLEX Data Collection.
-
-It is possible to define contributors in the CLEX Data Collection, some of the potential contributor roles are:
-
-* Reviewer 
-  To qualify, the review needs to be a substantial effort, which results in improvements/changes being applied to the dataset. 
-
-* Curator 
-  Person tasked with reviewing, enhancing, cleaning, or standardizing the data and the associated metadata in a way that goes beyond the ordinary curation of the data collection
-
-* Content-expert 
-  Someone who contributed mainly by providing advice/review on the scientific validity of the data
-
-These definitions are based on the authorship and co-authorship policy on the Australian Code for the Responsible Conduct of Research 2018.
-
-You can only submit a modified dataset if the modifications add value to the data. For example, if you have applied some correction to an existing dataset, this effectively add values to the original data. Re-gridding a dataset is not enough to consider this a new dataset. The best option in this case is to cite the original data and the re-gridding code.
-
-When submitting a modified dataset, the authors are responsible to ensure the licensing and ethical terms of the original data allow for that submission. 
+> You can only submit a dataset for which you are an author. 
+> 
+> An author is a person who has created or modified a dataset in a substantial way, either as an individual or part of a group effort. 
+> A dataset can have several co-authors. All co-authors should have made a significant contribution to the data. Each author needs to give their agreement to be listed as an author. In addition, if some co-authors are not from CLEX, they should give their agreement for the code to be listed under the CLEX Data Collection.
+> 
+> It is possible to define contributors in the CLEX Data Collection, some of the potential contributor roles are:
+> 
+> * Reviewer 
+>   To qualify, the review needs to be a substantial effort, which results in improvements/changes being applied to the dataset. 
+>
+> * Curator 
+>   Person tasked with reviewing, enhancing, cleaning, or standardizing the data and the associated metadata in a way that goes beyond the ordinary curation of the data collection
+>
+> * Content-expert 
+>   Someone who contributed mainly by providing advice/review on the scientific validity of the data
+>
+> These definitions are based on the authorship and co-authorship policy on the Australian Code for the Responsible Conduct of Research 2018.
+>
+> You can only submit a modified dataset if the modifications add value to the data. For example, if you have applied some correction to an existing dataset, this effectively add values to the original data. Re-gridding a dataset is not enough to consider this a new dataset. The best option in this case is to cite the original data and the re-gridding code.
+> 
+> When submitting a modified dataset, the authors are responsible to ensure the licensing and ethical terms of the original data allow for that submission. 

--- a/Governance/manage/manage-project.md
+++ b/Governance/manage/manage-project.md
@@ -57,6 +57,6 @@ Covering the accounting tools available to handle storage allocations at NCI is 
 
 ```{warning}
 On older `gdata` filesystems at NCI, data can be assigned to a project different from the group folder where it is located. This can be identified by the `nci-files-report` command as it shows both project and group folder usage.
-As a result, data can be transferred to count against the quota of a different project than where it lives, and cause the target project to reach its storage quota. This can cause unforeseen issues for data projects who tipically have a lot of users and can result in automatic dataset update to fail for lack of storage.
+As a result, data can be transferred to count against the quota of a different project than where it lives, and cause the target project to reach its storage quota. This can cause unforeseen issues for data projects who typically have a lot of users and can result in automatic dataset update to fail for lack of storage.
 From `gdata5` on, it is not possible to assign data to a project different from the group folder.
 ```

--- a/Governance/manage/manage-project.md
+++ b/Governance/manage/manage-project.md
@@ -48,9 +48,15 @@ On CSIRO internal resources, access mgmt is governed by windows ACLs - email hel
 
 ## Backup
 `gdata` is not backed up, if the dataset files would be difficult to retrieve, or if they are the authoritative copy, it is important to have a [backup plan](../concepts/backup.md). If the files are an authoritative copy it might be worth backing up the data on a separate system. 
-The only option to back up data at NCI is to archive the data on the tape system also known as `[massdata](massdata)`.
+The only option to back up data at NCI is to archive the data on the tape system also known as `[massdata](../tech/massdata)`.
 
 If the datasets are a replica and they can be easily retrieved, or are frequently changing, then backing up the data might be redundant.
 
 ## Accounting
 Covering the accounting tools available to handle storage allocations at NCI is behind the scope of this guidance, but you can refer to [this blog from the CLEX CMS](https://climate-cms.org/posts/2022-04-26-storage-where-what-why-how.html) to get an overview.
+
+```{warning}
+On older `gdata` filesystems at NCI, data can be assigned to a project different from the group folder where it is located. This can be identified by the `nci-files-report` command as it shows both project and group folder usage.
+As a result, data can be transferred to count against the quota of a different project than where it lives, and cause the target project to reach its storage quota. This can cause unforeseen issues for data projects who tipically have a lot of users and can result in automatic dataset update to fail for lack of storage.
+From `gdata5` on, it is not possible to assign data to a project different from the group folder.
+```

--- a/Governance/retire/retire-replica.md
+++ b/Governance/retire/retire-replica.md
@@ -26,7 +26,7 @@ Even if there is a reliable automatic measure of data access, it is always a goo
 * **Automated download of updated datasets:** when a dataset is maintained from a 3rd party host automatically, then new versions can be automatically detected and downloaded and older versions or data with identified serious errata removed. This process is in place for NCI's CMIP replica data using the `synda` tool.
 
 ### Community feedback
-* **E-mail communication:** this is possible where the community is well defined, such as if users need to sign up to a group/project or if there are a well defined community of potential users. For example, if the data is on NCI, Mancini ([http://my.nci.org.au](my.nci.org.au)) can be used to contact projects' users. This might be sufficient when a likely candidate for removal has already been identified.
+* **E-mail communication:** this is possible where the community is well defined, such as if users need to sign up to a group/project or if there are a well defined community of potential users. For example, if the data is on NCI, Mancini ([my.nci.org.au](https://my.nci.org.au)) can be used to contact projects' users. This might be sufficient when a likely candidate for removal has already been identified.
 * **Survey:** this can be useful when several datasets need to be evaluated at one time, or work out which subset of a big dataset could be retired.
 * **Project dependence:** if a dataset was replicated as part of a particular research project, then it can be considered for removal on completion of that project unless input data is required for reproducibility for some specified period.
 

--- a/Governance/tech/contributors.md
+++ b/Governance/tech/contributors.md
@@ -1,0 +1,88 @@
+# Contributor roles
+
+This is a glossary of contributor roles based on the [Datacite Schema 4.4](https://schema.datacite.org/meta/kernel-4.4/).
+
+```{glossary}
+ContactPerson
+    Person with knowledge of how to access, troubleshoot, or otherwise field issues related to the resource.<br> 
+    It may also be the “Point of Contact” in an organisation that controls access to the resource, if that organisation is different from the Publisher, Distributor, and Data Manager.
+
+DataCollector
+    Person/institution responsible for finding or gathering/collecting data under the guidelines of the author(s) or Principal Investigator (PI).<br>
+    It may also be used when crediting survey conductors, interviewers, event or condition observers, or persons responsible for monitoring key instrument data.
+
+DataCurator
+    Person tasked with reviewing, enhancing, cleaning, or standardizing metadata and the associated data submitted for storage, use, and maintenance within a data centre or repository.<br>
+    While the DataManager is concerned with digital maintenance, the DataCurator’s role encompasses quality assurance focused on content and metadata. DataCurator responsibilities include: checking completeness of the submitted dataset against the content as described by the submitter; verifying standard metadata according to the applicable system or schema; adding or verifying specialized metadata to add value and ensure access across disciplines; and determining how the metadata might map to search engines, database products, and automated feeds.<br> 
+    Repository managers as well as data librarians working in the repository fall within this category. 
+
+DataManager
+    Person (or organisation with a staff of data managers, such as a data centre) responsible for maintaining the finished resource.<br>
+    The work done by this person or organisation ensures that the resource is periodically “refreshed” in terms of software/hardware support, is kept available or is protected from unauthorized access, is stored in accordance with industry standards, and is handled in accordance with the records management requirements applicable to it. 
+
+Distributor
+    Institution tasked with responsibility to generate/disseminate copies of the resource in either electronic or print form.<br>
+    Works stored in more than one archive/repository may credit each as a distributor.
+
+Editor
+    A person who oversees the details related to the publication format of the resource.<br>
+    Note: if the Editor is to be credited in place of multiple creators, the Editor’s name may be supplied as Creator, with “(Ed.)” appended to the name.
+
+HostingInstitution
+    Typically, the organisation allowing the resource to be available on the internet through the provision of its hardware/software/operating support.<br> 
+    This role normally falls on the University, research center or organization where the data center/data repository belongs. It may also be used for an organisation that stores the data offline - often a data centre if that data centre is not the “publisher” of the resource.
+
+Producer
+    Typically, a person or organisation responsible for the artistry and form of a media product.<br>
+    In the data industry, this may be a company “producing” DVDs that package data for future dissemination by a distributor.
+
+ProjectLeader
+    Person officially designated as head of project team or sub-project team instrumental in the work necessary to development of the resource.<br> 
+    The Project Leader is not “removed” from the work that resulted in the resource; he or she remains intimately involved throughout the life of the particular project team.
+
+ProjectManager
+    Person officially designated as manager of a project.<br> 
+    Project may consist of one or many project teams and sub-teams. The manager of a project normally has more administrative responsibility than actual work involvement.
+
+ProjectMember
+    Person on the membership list of a designated project.<br> 
+    This role may or may not indicate the quality, quantity, or substance of the person’s involvement.
+
+RegistrationAgency
+    Institution/organisation officially appointed by a Registration Authority to handle specific tasks within a defined area of responsibility.<br> 
+    For example, DataCite is a Registration Agency for the International DOI Foundation (IDF) in charge of assinging DOIs.
+
+RegistrationAuthority
+    A standards-setting body from which Registration Agencies obtain official recognition and guidance.<br>
+    The IDF serves as the Registration Authority for the International Standards Organisation (ISO) in the area/domain of Digital Object Identifiers.
+
+RelatedPerson
+    A person without a specifically defined role in the development of the resource, but who is someone the author wishes to recognize.<br> 
+    This person could be an author’s intellectual mentor, a person providing intellectual leadership in the discipline or subject domain, etc.
+
+Researcher
+    A person involved in analysing data or the results of an experiment or formal study.<br>
+    It may indicate an intern or assistant to one of the authors who helped with research but who was not so “key” as to be listed as an author. It should be a person, not an institution. Note that a person involved in the gathering of data would fall under the contributorType “DataCollector.” The researcher may find additional data online and correlate it to the data collected for the experiment or study, for example.
+
+ResearchGroup
+    Typically refers to a group of individuals with a lab, department, or division that has a specifically defined focus of activity.<br>
+    It may operate at a narrower level of scope; may or may not hold less administrative responsibility than a project team. 
+
+RightsHolder
+    Person or institution owning or managing property rights, including intellectual property rights over the resource.
+
+Sponsor
+    Person or organisation that issued a contract or under the auspices of which a work has been written, printed, published, developed, etc.<br>
+    It includes organisations that provide in-kind support, through donation, provision of people or a facility or instrumentation necessary for the development of the resource, etc.
+
+Supervisor
+    Designated administrator over one or more groups/teams working to produce a resource, or over one or more steps of a development process.
+
+WorkPackageLeader
+    A Work Package is a recognized data product, not all of which is included in publication.<br> 
+    The package, instead, may include notes, discarded documents, etc. The Work Package Leader is responsible for ensuring the comprehensive contents, versioning, and availability of the Work Package during the development of the resource.
+
+Other
+    Any person or institution making a significant contribution to the development and/or maintenance of the resource, but whose contribution is not adequately described by any of the other values for contributorType.<br>
+    It could be a photographer, artist, or writer whose contribution helped to publicize the resource (as opposed to creating it), a reviewer of the resource, someone providing administrative services to the author (such as depositing updates into an online repository, analysing usage, etc.), or one of many other roles.
+```

--- a/Governance/tech/title.md
+++ b/Governance/tech/title.md
@@ -1,10 +1,15 @@
 # Descriptive title
 
-That you are publishing your data or code it is important to have a good title for your new record. Like you probably carefully choose a title for your papers, so you should try to put some effort in creating a good title for othe research outputs. The title will be in any reference to your data or code.  While, depending on the repository you are using to publish, you can potentially change the title, even after a record has been published, it is important to get it right and be as descriptive as possible.
+When publishing data or code it is important to have a descriptive title for the new record. Paper titles are carefully chosen, the same effort should go in creating an effective title for other research outputs, as the title will be in any reference to the data or code. Depending on the repository used to publish, it might be possible to change the title even after a record has been published, however this is best avoided.
 
-Also most people querying a repository will skim quickly through the list of returned records. All they will see initially is the title and the start of the description, until they actually click on one specific record.
+Most people querying a repository will skim quickly through the list of returned records. All they will see initially is the title and the start of the description. Also, any word in the title is used as a keyword by free text search engine.
 
-And finally any word in the title is used as a keyword by free text search engine.
+## What to include
+Keeping in mind that the title words are used as keywords, a good rule of thumb is to include the sort of information that a potential user might choose for a search. The most important are probably the kind of data, the region, temporal coverage and frequency of the data. 
+Where it is relevant the source of the data should also be included, for example if this is a dataset derived from CMIP6, it might be interesting for anyone searching for CMIP6 data. If it is a model output, the name and version of the model would give a lot of useful information to understand the potential use of the data.
+If publishing data or code underlining a paper publication usually this is clearly stated in the title. Similarly, it can be useful to mention the project associated to the research output, as giving the context in which the data or code was created can also clarify potential future use for them.
+
+If publishing code, it is important to include its scope and how it can be run, so including the language on which is based and potentially a specific environment for which it was created.
 
 ## Data example
 "Weather Research and Forecasting (v3.6) model outputs from 2-km Kuala Lumpur urban climate experiments"
@@ -17,7 +22,10 @@ In the example above the author tried to include:
 * spatial domain - Kuala Lumpur
 * subject - urban climate
 * that there is more than 1 experiment - experiments
-NB that having used the full model name rather than an acronym clarified to any user not familiar with WRF that this are weather forecast related experiment
+<br>
+```{note}
+Having used the full model's name rather than an acronym clarified to any user not familiar with WRF that these are weather forecast related experiments.
+```
 
 ## Code example
 "CleF - Climate Finder a python based command line tool to query ESGF datasets hosted at NCI"

--- a/Governance/tech/title.md
+++ b/Governance/tech/title.md
@@ -7,7 +7,7 @@ Most people querying a repository will skim quickly through the list of returned
 ## What to include
 Keeping in mind that the title words are used as keywords, a good rule of thumb is to include the sort of information that a potential user might choose for a search. The most important are probably the kind of data, the region, temporal coverage and frequency of the data. 
 Where it is relevant the source of the data should also be included, for example if this is a dataset derived from CMIP6, it might be interesting for anyone searching for CMIP6 data. If it is a model output, the name and version of the model would give a lot of useful information to understand the potential use of the data.
-If publishing data or code underlining a paper publication usually this is clearly stated in the title. Similarly, it can be useful to mention the project associated to the research output, as giving the context in which the data or code was created can also clarify potential future use for them.
+If publishing data or code underlining a paper publication usually this is clearly stated in the title. Similarly, it can be useful to mention the project associated to the research output, as giving the context in which the data or code was created can also clarify potential future use.
 
 If publishing code, it is important to include its scope and how it can be run, so including the language on which is based and potentially a specific environment for which it was created.
 


### PR DESCRIPTION
added authorship page in concepts, to clarify who is an author who is a contributor and introduce authorship policy
Add contributor roles page in tech section, this is linked from the authorship page, both are linked to issue #17.

solved issue #46 and #47 

finally fixed a couple of broken references 